### PR TITLE
Modified the resource for the queue manager. If you rename the queue …

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,10 @@ maintainer_email 'arthur.barr@uk.ibm.com'
 license 'Apache 2.0'
 description 'Installs/Configures IBM MQ'
 long_description 'Installs/Configures IBM MQ'
-version '0.1.1'
+
+version '0.1.2'
+
+supports 'ubuntu'
+
 depends 'limits'
 depends 'yum'
-supports 'ubuntu'

--- a/resources/queue_manager.rb
+++ b/resources/queue_manager.rb
@@ -21,7 +21,7 @@ action :create do
     command "crtmqm #{new_resource.name}"
     user new_resource.user
     group 'mqm'
-    creates '/var/mqm/qmgrs/qm1/'
+    creates "/var/mqm/qmgrs/#{new_resource.name}/"
   end
 end
 


### PR DESCRIPTION
…manager in your recipe it keeps creating it on each chef run because it checks for the qm1 directory instead for the custom name you provided.